### PR TITLE
LRQA-76234 | master

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/administration/portalconfiguration/systemmanagement/InstanceSettings.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/administration/portalconfiguration/systemmanagement/InstanceSettings.testcase
@@ -388,6 +388,8 @@ definition {
 	@description = "This test asserts that a user can create multi factory configurations."
 	@priority = "4"
 	test CanCreateTwoFactoryConfigurations {
+		property test.name.skip.portal.instance = "InstanceSettings#CanCreateTwoFactoryConfigurations";
+
 		var openIdConnectClientId = PropsUtil.get("google.client.id.1");
 		var openIdConnectClientId1 = PropsUtil.get("google.client.id.2");
 		var openIdConnectClientSecret = PropsUtil.get("google.client.secret.1");
@@ -958,6 +960,8 @@ definition {
 
 	@priority = "4"
 	test FactoryConfigurationCanBeDeleted {
+		property test.name.skip.portal.instance = "InstanceSettings#FactoryConfigurationCanBeDeleted";
+
 		var openIdConnectClientId = PropsUtil.get("google.client.id.1");
 		var openIdConnectClientSecret = PropsUtil.get("google.client.secret.1");
 
@@ -995,6 +999,8 @@ definition {
 
 	@priority = "4"
 	test FactoryConfigurationCanBeEdited {
+		property test.name.skip.portal.instance = "InstanceSettings#FactoryConfigurationCanBeEdited";
+
 		var openIdConnectClientId = PropsUtil.get("google.client.id.1");
 		var openIdConnectClientSecret = PropsUtil.get("google.client.secret.1");
 
@@ -1079,6 +1085,8 @@ definition {
 
 	@priority = "4"
 	test SingleFactoryConfigurationCanBeExported {
+		property test.name.skip.portal.instance = "InstanceSettings#SingleFactoryConfigurationCanBeExported";
+
 		var openIdConnectClientId = PropsUtil.get("google.client.id.1");
 		var openIdConnectClientSecret = PropsUtil.get("google.client.secret.1");
 


### PR DESCRIPTION
https://issues.liferay.com/browse/LRQA-76234
Temporary workaround. At the moment, the InstanceSettings tests that deal with factory configurations are causing failures in many other tests that run in the same batch due to a bad cleanup. Having them run on separate instances allows for our tests within the InstanceSettings testcase to pass. This is being tracked in https://issues.liferay.com/browse/LPS-158349. 